### PR TITLE
fix: add regenerator runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@babel/core": "^7.12.3",
+    "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.5",
     "@material-ui/core": "^4.11.0",
@@ -40,5 +41,8 @@
     "react-redux": "^7.2.2",
     "webpack": "^5.5.0",
     "webpack-cli": "^4.2.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.12.5"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,8 @@ const config = {
         exclude: /(node_modules)/,
         loader: 'babel-loader',
         options: {
-          presets: ['@babel/preset-env', '@babel/preset-react']
+          presets: ['@babel/preset-env', '@babel/preset-react'],
+          plugins: ['@babel/plugin-transform-runtime']
         }
      }
     ]


### PR DESCRIPTION
This avoids 'regeneratorRuntime' errors on client applications, like this error running cra - sample app:

```
oauthSlice.js:70 Uncaught ReferenceError: regeneratorRuntime is not defined
    at eval (oauthSlice.js:70)
    at eval (oauthSlice.js:103)
    at Object.srcReduxOauthSliceJs [as ./src/redux/oauthSlice.js] (index.js:112)
    at __webpack_require__ (index.js:284)
    at eval (OAuthLogin.js:14)
    at Object.srcOauthOAuthLoginJs [as ./src/oauth/OAuthLogin.js] (index.js:47)
    at __webpack_require__ (index.js:284)
    at eval (index.js:8)
    at Object.srcOauthIndexJs [as ./src/oauth/index.js] (index.js:63)
    at __webpack_require__ (index.js:284)
```