### PR TITLE
Fix addSource allowing custom credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-# 1.0.0-beta3 (2020-11-24)
+## Not released
+- Fix addSource, keeping optional credentials property in the payload [#22](https://github.com/CartoDB/carto-react-lib/pull/22)
+
+## 1.0.0-beta3 (2020-11-24)
 - Improve package.json metadata + README inclusion in npm publication [#20](https://github.com/CartoDB/carto-react-lib/pull/20)
 
-# 1.0.0-beta2 (2020-11-23)
+## 1.0.0-beta2 (2020-11-23)
 - Fix missing regenerator runtime in the build [#13](https://github.com/CartoDB/carto-react-lib/pull/13)
 - Doc updates for api reference
 
-# 1.0.0-beta1 (2020-11-20)
+## 1.0.0-beta1 (2020-11-20)
 - Initial release: api, basemaps, oauth, redux and ui

--- a/src/redux/cartoSlice.js
+++ b/src/redux/cartoSlice.js
@@ -112,8 +112,9 @@ export const createCartoSlice = (initialState) => {
  * @param {string} id - unique id for the source
  * @param {string} data - data definition for the source. Query for SQL dataset or the name of the tileset for BigQuery Tileset
  * @param {string} type - type of source. Posible values are sql or bq
+ * @param {Object} credentials - (optional) Custom credentials to be used in the source
  */
-export const addSource = ({id, data, type}) => ({ type: 'carto/addSource', payload: {id, data, type}});
+export const addSource = ({id, data, type, credentials}) => ({ type: 'carto/addSource', payload: {id, data, type, credentials}});
 
 /**
  * Action to remove a source from the store


### PR DESCRIPTION
This fixes issues when dealing with sources for OAuth authenticated contents, where apiKey must be overriden by token (custom `credentials` in the payload).