### PR TITLE
Fix CategoryWidgetUI loading and no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Unreleased
+# CHANGELOG
+
+## Not released
+- Fix CategoryWidgetUI displaying no data while loading [#26](https://github.com/CartoDB/carto-react-lib/pull/26)
 - Make OAuthLogin component responsive [#28](https://github.com/CartoDB/carto-react-lib/pull/28)
 
 ## 1.0.0-beta5 (2020-11-25)

--- a/src/ui/widgets/CategoryWidgetUI.js
+++ b/src/ui/widgets/CategoryWidgetUI.js
@@ -450,7 +450,7 @@ function CategoryWidgetUI(props) {
                     }
                   />
                 ))
-              : data.length === 0 && (
+              : (data.length === 0 && !loading) && (
                   <Alert severity='warning'>
                     <AlertTitle>NO DATA AVAILABLE</AlertTitle>
                     There are no results for the combination of filters applied to your


### PR DESCRIPTION
Issue reported by QA: "When I first access, I see the "loading skeleton" properly, but there is a blink and a "no data" message shows before showing the final content"

![image](https://user-images.githubusercontent.com/458196/100217555-dfc44c80-2f13-11eb-9dfd-dfeaa5936d15.png)

