### PR TITLE
fix: keep the order when blocking categories in CategoryWidgetUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 - Fix CategoryWidgetUI displaying no data while loading [#26](https://github.com/CartoDB/carto-react-lib/pull/26)
+- Fix CategoryWidgetUI keeping the order for blocked categories [#27](https://github.com/CartoDB/carto-react-lib/pull/27)
 - Make OAuthLogin component responsive [#28](https://github.com/CartoDB/carto-react-lib/pull/28)
 
 ## 1.0.0-beta5 (2020-11-25)

--- a/src/ui/widgets/CategoryWidgetUI.js
+++ b/src/ui/widgets/CategoryWidgetUI.js
@@ -150,22 +150,26 @@ function CategoryWidgetUI(props) {
   };
 
   const handleBlockClicked = () => {
-    // keep the 'by value' order on selectedCategories
-    const orderedCategories = data.sort((cat1, cat2)=> (cat1.value > cat2.value) ? -1 : 1);
-    const newBlockedCategories = orderedCategories
-      .filter(entry => selectedCategories.includes(entry.category))
-      .map(entry => entry.category);
-
-    setBlockedCategories([...newBlockedCategories]);
+    setBlockedCategoriesKeepingOrder(selectedCategories);
   };
 
   const handleApplyClicked = () => {
     props.onSelectedCategoriesChange([...tempBlockedCategories]);
-    setBlockedCategories([...tempBlockedCategories]);
+    setBlockedCategoriesKeepingOrder(tempBlockedCategories);
     setTempBlockedCategories([]);
     setShowAll(false);
     setSearchValue('');
   };
+
+  const setBlockedCategoriesKeepingOrder = (blockedCategories) => {
+     // keep the 'by value' order on selectedCategories
+     const orderedCategories = data.sort((cat1, cat2)=> (cat1.value > cat2.value) ? -1 : 1);
+     const newBlockedCategories = orderedCategories
+       .filter(entry => blockedCategories.includes(entry.category))
+       .map(entry => entry.category);
+
+       setBlockedCategories([...newBlockedCategories]);
+  }
 
   const handleCancelClicked = () => {
     setSearchValue('');

--- a/src/ui/widgets/CategoryWidgetUI.js
+++ b/src/ui/widgets/CategoryWidgetUI.js
@@ -150,7 +150,13 @@ function CategoryWidgetUI(props) {
   };
 
   const handleBlockClicked = () => {
-    setBlockedCategories([...selectedCategories]);
+    // keep the 'by value' order on selectedCategories
+    const orderedCategories = data.sort((cat1, cat2)=> (cat1.value > cat2.value) ? -1 : 1);
+    const newBlockedCategories = orderedCategories
+      .filter(entry => selectedCategories.includes(entry.category))
+      .map(entry => entry.category);
+
+    setBlockedCategories([...newBlockedCategories]);
   };
 
   const handleApplyClicked = () => {


### PR DESCRIPTION
Keep the order of categories, even when 'blocking' some of them:

This is the issue:
![image](https://user-images.githubusercontent.com/458196/100226715-65e69000-2f20-11eb-88a7-8bc544560f9c.png)

