### PR TITLE
Fix blocked categories not sorted as original data [ch121772]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Animate CategoryWidget values [#30](https://github.com/CartoDB/carto-react-lib/pull/30)
 - Make OAuthLogin component responsive [#28](https://github.com/CartoDB/carto-react-lib/pull/28)
 - Remove FilterTypes from API exports [#29](https://github.com/CartoDB/carto-react-lib/pull/29)
+- Fix CategoryWidgetUI keeping the order for blocked categories [#32](https://github.com/CartoDB/carto-react-lib/pull/32)
 
 ## 1.0.0-beta5 (2020-11-25)
 - Fix addSource keeping optional credentials property in the payload [#24](https://github.com/CartoDB/carto-react-lib/pull/24)

--- a/src/ui/widgets/CategoryWidgetUI.js
+++ b/src/ui/widgets/CategoryWidgetUI.js
@@ -134,6 +134,12 @@ function CategoryWidgetUI(props) {
   const prevAnimValues = usePrevious(animValues);
   const classes = useStyles();
 
+  // Get blockedCategories in the same order as original data
+  const sortBlockedSameAsData = (blockedCategories) => sortedData.reduce((acum, elem) => {
+    if (blockedCategories.includes(elem.category)) acum.push(elem.category);
+    return acum;
+  }, []);
+
   const handleCategorySelected = (category) => {
     if (category !== REST_CATEGORY) {
       let categories;
@@ -159,13 +165,15 @@ function CategoryWidgetUI(props) {
     setBlockedCategories([]);
   };
 
-  const handleBlockClicked = () => {
-    setBlockedCategories([...selectedCategories]);
+  const handleBlockClicked = () => {    
+    setBlockedCategories(sortBlockedSameAsData(selectedCategories));
   };
 
   const handleApplyClicked = () => {
-    props.onSelectedCategoriesChange([...tempBlockedCategories]);
-    setBlockedCategories([...tempBlockedCategories]);
+    const blockedCategoriesOrdered = sortBlockedSameAsData(tempBlockedCategories);
+
+    props.onSelectedCategoriesChange([...blockedCategoriesOrdered]);
+    setBlockedCategories([...blockedCategoriesOrdered]);
     setTempBlockedCategories([]);
     setShowAll(false);
     setSearchValue('');


### PR DESCRIPTION
Related to point 5 in https://app.clubhouse.io/cartoteam/story/121772/qa-carto-for-react.

I propose this fix over the one in https://github.com/CartoDB/carto-react-lib/pull/27. @VictorVelarde take a look and tell me if it makes sense for you.