### PR TITLE
feat: add layerAttributes to addLayer and refactor updateLayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 - Remove OAuthLogin component (extracted to the template project) [#44](https://github.com/CartoDB/carto-react-lib/pull/44)
+- Add layerAttributes to addLayer and refactor updateLayer to use same destructuring approach [#45](https://github.com/CartoDB/carto-react-lib/pull/45)
 
 ## 1.0.0-beta7 (2020-12-04)
 - Add meta value example to List component story [#31](https://github.com/CartoDB/carto-react-lib/pull/31)

--- a/docs/api-reference/redux.md
+++ b/docs/api-reference/redux.md
@@ -54,6 +54,7 @@ Action to add a Layer to the store
 | --- | --- | --- |
 | id | <code>string</code> | unique id for the layer |
 | source | <code>string</code> | id of the source of the layer |
+| layerAttributes | <code>object</code> | (optional) custom attributes to pass to the layer |
 
 ### updateLayer
 Action to update a Layer in the store
@@ -61,14 +62,14 @@ Action to update a Layer in the store
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | unique id for the layer |
-| layerAttributes | <code>object</code> | layer attributes to update (source, or other custom attributes) |
+| layerAttributes | <code>object</code> | custom attributes to pass to the layer |
 
 ### removeLayer
 Action to remove a layer from the store
 
 | Param | Type | Description |
 | --- | --- | --- |
-| layerId | <code>string</code> | id of the layer to remove |
+| id | <code>string</code> | id of the layer to remove |
 
 ### setBaseMap
 Action to set a basemap

--- a/src/redux/cartoSlice.js
+++ b/src/redux/cartoSlice.js
@@ -128,21 +128,22 @@ export const removeSource = (sourceId) => ({ type: 'carto/removeSource', payload
  * Action to add a Layer to the store
  * @param {string} id - unique id for the layer
  * @param {string} source - id of the source of the layer
+ * @param {object} layerAttributes - custom attributes to pass to the layer 
  */
-export const addLayer = ({id, source}) => ({ type: 'carto/addLayer', payload: {id, source} });
+export const addLayer = ({id, source, layerAttributes = {}}) => ({ type: 'carto/addLayer', payload: {id, source, layerAttributes} });
 
 /**
  * Action to update a Layer in the store
  * @param {string} id - id of the layer to update
  * @param {object} layerAttributes - layer attributes to update (source, or other custom attributes)
  */
-export const updateLayer = (id, layerAttributes) => ({ type: 'carto/updateLayer', payload: {id, layerAttributes} });
+export const updateLayer = ({id, layerAttributes}) => ({ type: 'carto/updateLayer', payload: {id, layerAttributes} });
 
 /**
  * Action to remove a layer from the store
- * @param {string} layerId - id of the layer to remove 
+ * @param {string} id - id of the layer to remove 
  */
-export const removeLayer = (layerId) => ({ type: 'carto/removeLayer', payload: layerId});
+export const removeLayer = (id) => ({ type: 'carto/removeLayer', payload: id});
 
 /**
  * Action to set a basemap


### PR DESCRIPTION
This way they are both flexible to pass extra params to layers, and they both use the same destructuring approach