### PR TITLE
Fix basemap casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## unreleased
+- Fix basemap casing in store and action so `basemap` and `setBasemap` are used [#64](https://github.com/CartoDB/carto-react-lib/pull/64)
+
 ## 1.0.0-beta10 (2021-01-14)
 
 - Fix WrapperWidgetUI anchorOrigin error [#55](https://github.com/CartoDB/carto-react-lib/pull/55)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## unreleased
+## 1.0.0-beta11 (2021-01-22)
 - Fix basemap casing in store and action so `basemap` and `setBasemap` are used [#64](https://github.com/CartoDB/carto-react-lib/pull/64)
 
 ## 1.0.0-beta10 (2021-01-14)

--- a/docs/api-reference/redux.md
+++ b/docs/api-reference/redux.md
@@ -71,7 +71,7 @@ Action to remove a layer from the store
 | --- | --- | --- |
 | id | <code>string</code> | id of the layer to remove |
 
-### setBaseMap
+### setBasemap
 Action to set a basemap
 
 | Param | Type | Description |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react",
-  "version": "1.0.0-beta10",
+  "version": "1.0.0-beta11",
   "description": "CARTO for React",
   "scripts": {
     "start": "rm -rf dist && mkdir dist && cp package.json ./dist/package.json && webpack --config webpack.prod.js --watch",

--- a/src/redux/cartoSlice.js
+++ b/src/redux/cartoSlice.js
@@ -66,7 +66,7 @@ export const createCartoSlice = (initialState) => {
       removeLayer: (state, action) => {
         delete state.layers[action.payload];
       },
-      setBaseMap: (state, action) => {
+      setBasemap: (state, action) => {
         state.basemap = action.payload;
       },
       setViewState: (state, action) => {
@@ -157,7 +157,7 @@ export const removeLayer = (id) => ({ type: 'carto/removeLayer', payload: id});
  * Action to set a basemap
  * @param {String} basemap - the new basemap to add 
  */
-export const setBaseMap = (basemap) => ({ type: 'carto/setBaseMap', payload: basemap });
+export const setBasemap = (basemap) => ({ type: 'carto/setBasemap', payload: basemap });
 
 /**
  * Action to add a filter on a given source and column

--- a/src/redux/cartoSlice.js
+++ b/src/redux/cartoSlice.js
@@ -39,7 +39,7 @@ export const createCartoSlice = (initialState) => {
       viewport: undefined,
       geocoderResult: null,
       error: null,
-      baseMap: 'positron',
+      basemap: 'positron',
       layers: {
         // Auto import layers
       },
@@ -67,7 +67,7 @@ export const createCartoSlice = (initialState) => {
         delete state.layers[action.payload];
       },
       setBaseMap: (state, action) => {
-        state.baseMap = action.payload;
+        state.basemap = action.payload;
       },
       setViewState: (state, action) => {
         const viewState = action.payload;

--- a/src/widgets/GeocoderWidget.js
+++ b/src/widgets/GeocoderWidget.js
@@ -158,6 +158,7 @@ function GeocoderWidget(props) {
         placeholder='Search address'
         className={classes.input}
         value={searchText}
+        name='GeocoderSearch'
         onChange={handleChange}
         onInput={handleInput}
         onKeyDown={handleKeyPress}


### PR DESCRIPTION
Internally the action to set a basemap was setting the store value to 'baseMap'. But 'basemap' was being used all around. 

So in this PR we go for 'basemap', for both the store prop (`carto.basemap`) and the action (`setBasemap`)