### PR TITLE
fix: await for rejections in tests

### DIFF
--- a/src/tests/widgets/models/CategoryModel.test.js
+++ b/src/tests/widgets/models/CategoryModel.test.js
@@ -10,22 +10,18 @@ import { LayerTypes } from 'src/widgets/LayerTypes';
 import { POINTS } from '../data-mocks/pointsForCategories';
 
 describe('getCategories', () => {
-  test('should thrown an error due to invalid data type', () => {
-    try {
-      getCategories({ data: [] });
-    } catch (err) {
-      expect(err).toBe('Array is not a valid type to get categories');
-    }
+  test('should thrown an error due to invalid data type', async () => {
+    await expect(getCategories({ data: [] })).rejects.toThrow(
+      'Array is not a valid type to get categories'
+    );
   });
 
-  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', () => {
-    try {
-      getCategories({ type: LayerTypes.BQ, viewportFilter: true });
-    } catch (err) {
-      expect(err).toBe(
-        'Category Widget error: BigQuery layers need "viewportFilter" prop set to true.'
-      );
-    }
+  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
+    await expect(
+      getCategories({ type: LayerTypes.BQ, viewportFilter: false })
+    ).rejects.toThrow(
+      'Category Widget error: BigQuery layers need "viewportFilter" prop set to true.'
+    );
   });
 
   describe('buildSqlQueryToGetCategories - simple global operations', () => {

--- a/src/tests/widgets/models/CategoryModel.test.js
+++ b/src/tests/widgets/models/CategoryModel.test.js
@@ -10,13 +10,13 @@ import { LayerTypes } from 'src/widgets/LayerTypes';
 import { POINTS } from '../data-mocks/pointsForCategories';
 
 describe('getCategories', () => {
-  test('should thrown an error due to invalid data type', async () => {
+  test('should throw an error due to invalid data type', async () => {
     await expect(getCategories({ data: [] })).rejects.toThrow(
       'Array is not a valid type to get categories'
     );
   });
 
-  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
+  test('should throw an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
     await expect(
       getCategories({ type: LayerTypes.BQ, viewportFilter: false })
     ).rejects.toThrow(

--- a/src/tests/widgets/models/FormulaModel.test.js
+++ b/src/tests/widgets/models/FormulaModel.test.js
@@ -10,22 +10,18 @@ import { LayerTypes } from 'src/widgets/LayerTypes';
 import { LINES } from '../data-mocks/linesForFormula';
 
 describe('getFormula', () => {
-  test('should thrown an error due to invalid data type', () => {
-    try {
-      getFormula({ data: [] });
-    } catch (err) {
-      expect(err).toBe('Array is not a valid type to get formula');
-    }
+  test('should thrown an error due to invalid data type', async () => {
+    await expect(getFormula({ data: [] })).rejects.toThrow(
+      'Array is not a valid type to get formula'
+    );
   });
 
-  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', () => {
-    try {
-      getFormula({ type: LayerTypes.BQ, viewportFilter: true });
-    } catch (err) {
-      expect(err).toBe(
-        'Formula Widget error: BigQuery layers need "viewportFilter" prop set to true.'
-      );
-    }
+  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
+    await expect(
+      getFormula({ type: LayerTypes.BQ, viewportFilter: false })
+    ).rejects.toThrow(
+      'Formula Widget error: BigQuery layers need "viewportFilter" prop set to true.'
+    );
   });
 
   describe('buildSqlQueryToGetFormula - simple global operations', () => {

--- a/src/tests/widgets/models/FormulaModel.test.js
+++ b/src/tests/widgets/models/FormulaModel.test.js
@@ -10,13 +10,13 @@ import { LayerTypes } from 'src/widgets/LayerTypes';
 import { LINES } from '../data-mocks/linesForFormula';
 
 describe('getFormula', () => {
-  test('should thrown an error due to invalid data type', async () => {
+  test('should throw an error due to invalid data type', async () => {
     await expect(getFormula({ data: [] })).rejects.toThrow(
       'Array is not a valid type to get formula'
     );
   });
 
-  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
+  test('should throw an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
     await expect(
       getFormula({ type: LayerTypes.BQ, viewportFilter: false })
     ).rejects.toThrow(

--- a/src/tests/widgets/models/HistogramModel.test.js
+++ b/src/tests/widgets/models/HistogramModel.test.js
@@ -10,13 +10,13 @@ import { LayerTypes } from 'src/widgets/LayerTypes';
 import { POLYGONS } from '../data-mocks/polygonsForHistogram';
 
 describe('getHistogram', () => {
-  test('should thrown an error due to invalid data type', async () => {
+  test('should throw an error due to invalid data type', async () => {
     await expect(getHistogram({ data: [] })).rejects.toThrow(
       'Array is not a valid type to get histogram'
     );
   });
 
-  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
+  test('should throw an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
     await expect(
       getHistogram({ type: LayerTypes.BQ, viewportFilter: false })
     ).rejects.toThrow(

--- a/src/tests/widgets/models/HistogramModel.test.js
+++ b/src/tests/widgets/models/HistogramModel.test.js
@@ -10,22 +10,18 @@ import { LayerTypes } from 'src/widgets/LayerTypes';
 import { POLYGONS } from '../data-mocks/polygonsForHistogram';
 
 describe('getHistogram', () => {
-  test('should thrown an error due to invalid data type', () => {
-    try {
-      getHistogram({ data: [] });
-    } catch (err) {
-      expect(err).toBe('Array is not a valid type to get histogram');
-    }
+  test('should thrown an error due to invalid data type', async () => {
+    await expect(getHistogram({ data: [] })).rejects.toThrow(
+      'Array is not a valid type to get histogram'
+    );
   });
 
-  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', () => {
-    try {
-      getHistogram({ type: LayerTypes.BQ, viewportFilter: true });
-    } catch (err) {
-      expect(err).toBe(
-        'Category Widget error: BigQuery layers need "viewportFilter" prop set to true.'
-      );
-    }
+  test('should thrown an error if trying to implement client-side-logic with CartoBQTilerLayer', async () => {
+    await expect(
+      getHistogram({ type: LayerTypes.BQ, viewportFilter: false })
+    ).rejects.toThrow(
+      'Histogram Widget error: BigQuery layer needs "viewportFilter" prop set to true.'
+    );
   });
 
   describe('buildSqlQueryToGetHistogram - simple global operations', () => {


### PR DESCRIPTION
Handling rejections in `/widgets/models` tests.