### PR TITLE
fix: nº of categories counter when some are blocked on Category Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix an issue on histogram's operations when processing a not finite value [#79](https://github.com/CartoDB/carto-react-lib/pull/79)
 - Add sourcemaps and production mode in webpack bundles [#83](https://github.com/CartoDB/carto-react-lib/pull/83)
+- Fix number of categories counter when some are locked on Category Widget [#81](https://github.com/CartoDB/carto-react-lib/pull/81)
 
 ## 1.0.0-beta13 (2021-02-02)
 

--- a/src/ui/widgets/CategoryWidgetUI.js
+++ b/src/ui/widgets/CategoryWidgetUI.js
@@ -344,6 +344,11 @@ function CategoryWidgetUI(props) {
     return () => cancelAnimationFrame(requestRef.current);
   }, [sortedData]);
 
+  const getCategoriesCount = useCallback(() => {
+    const blocked = blockedCategories.length;
+    return blocked ? data.length - blocked : data.length - maxItems;
+  }, [data, maxItems, blockedCategories]);
+
   // Separated to simplify the widget layout but inside the main component to avoid passing all dependencies
   const CategoryItem = (props) => {
     const { data, onCategoryClick } = props;
@@ -528,7 +533,7 @@ function CategoryWidgetUI(props) {
                 startIcon={<SearchIcon />}
                 onClick={handleShowAllCategoriesClicked}
               >
-                Search in {data.length - maxItems} elements
+                Search in {getCategoriesCount()} elements
               </Button>
             )
           ) : null}


### PR DESCRIPTION
Fix number of categories counter when some some are blocked on Category Widget

For: https://app.clubhouse.io/cartoteam/story/tra/qa-categories-widget-n-of-categories-counter