### PR TITLE
refactor: rename bigquery source type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - Improve performance widget client side calculations [#88](https://github.com/CartoDB/carto-react-lib/pull/88)
+- Refactor BigQuery source type name [#97](https://github.com/CartoDB/carto-react-lib/pull/97)
 
 ## 1.0.0-beta14 (2021-02-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Not released
 
 - Improve performance widget client side calculations [#88](https://github.com/CartoDB/carto-react-lib/pull/88)
-- Refactor BigQuery source type name [#97](https://github.com/CartoDB/carto-react-lib/pull/97)
+- Change BigQuery source type name from 'bq' to 'bigquery' [#97](https://github.com/CartoDB/carto-react-lib/pull/97)
 
 ## 1.0.0-beta14 (2021-02-08)
 

--- a/docs/api-reference/redux.md
+++ b/docs/api-reference/redux.md
@@ -41,7 +41,7 @@ Parameters are in the form of destructuring arguments.
 | ------ | ------------------- | ----------------------------------------------------------------------------------------------------- |
 | {id}   | <code>string</code> | unique id for the source                                                                              |
 | {data} | <code>string</code> | data definition for the source. Query for SQL dataset or the name of the tileset for BigQuery Tileset |
-| {type} | <code>string</code> | type of source. Posible values are sql or bq                                                          |
+| {type} | <code>string</code> | type of source. Posible values are sql or bigquery                                                    |
 
 ### removeSource
 

--- a/docs/api-reference/redux.md
+++ b/docs/api-reference/redux.md
@@ -41,7 +41,7 @@ Parameters are in the form of destructuring arguments.
 | ------ | ------------------- | ----------------------------------------------------------------------------------------------------- |
 | {id}   | <code>string</code> | unique id for the source                                                                              |
 | {data} | <code>string</code> | data definition for the source. Query for SQL dataset or the name of the tileset for BigQuery Tileset |
-| {type} | <code>string</code> | type of source. Posible values are sql or bigquery                                                    |
+| {type} | <code>string</code> | type of source. Posible values are 'sql' or 'bigquery'                                                |
 
 ### removeSource
 

--- a/docs/api-reference/widgets.md
+++ b/docs/api-reference/widgets.md
@@ -87,9 +87,9 @@ Enum for the different types of aggregations available for widgets
 </dd>
 </dl>
 
-## LayerTypes
+## SourceTypes
 
-Enum for the different types of @deck.gl/carto layers
+Enum for the different types of @deck.gl/carto sources
 
 **Kind**: global enum  
 **Read only**: true

--- a/docs/api-reference/widgets.md
+++ b/docs/api-reference/widgets.md
@@ -98,7 +98,7 @@ Enum for the different types of @deck.gl/carto layers
 <dt><a href="#SQL">SQL</a></dt>
 <dd><p>sql</p>
 </dd>
-<dt><a href="#BQ">BQ</a></dt>
-<dd><p>bq</p>
+<dt><a href="#BIGQUERY">BIGQUERY</a></dt>
+<dd><p>bigquery</p>
 </dd>
 </dl>

--- a/src/api/SourceTypes.js
+++ b/src/api/SourceTypes.js
@@ -1,9 +1,9 @@
 /**
- * Enum for the different types of @deck.gl/carto layers
+ * Enum for the different types of @deck.gl/carto sources
  * @enum {string}
  * @readonly
  */
-export const LayerTypes = Object.freeze({
+export const SourceTypes = Object.freeze({
   /** CartoSQLLayer */
   SQL: 'sql',
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -3,3 +3,4 @@ export { executeSQL } from './SQL';
   buildQueryFilters,
 } from './FilterQueryBuilder'; */
 export { default as useCartoLayerFilterProps } from './useCartoLayerFilterProps';
+export { SourceTypes } from './SourceTypes';

--- a/src/redux/cartoSlice.js
+++ b/src/redux/cartoSlice.js
@@ -164,7 +164,7 @@ export const createCartoSlice = (initialState) => {
  *
  * @param {string} id - unique id for the source
  * @param {string} data - data definition for the source. Query for SQL dataset or the name of the tileset for BigQuery Tileset
- * @param {string} type - type of source. Posible values are sql or bq
+ * @param {string} type - type of source. Posible values are sql or bigquery
  * @param {Object} credentials - (optional) Custom credentials to be used in the source
  */
 export const addSource = ({ id, data, type, credentials }) => ({

--- a/src/tests/widgets/models/CategoryModel.test.js
+++ b/src/tests/widgets/models/CategoryModel.test.js
@@ -34,7 +34,7 @@ describe('getCategories', () => {
 
   test('should throw if using CartoBQTilerLayer without viewportFilter', async () => {
     await expect(
-      getCategories({ type: LayerTypes.BQ, viewportFilter: false })
+      getCategories({ type: LayerTypes.BIGQUERY, viewportFilter: false })
     ).rejects.toThrow(
       'Category Widget error: BigQuery layers need "viewportFilter" prop set to true.'
     );

--- a/src/tests/widgets/models/CategoryModel.test.js
+++ b/src/tests/widgets/models/CategoryModel.test.js
@@ -6,7 +6,7 @@ import {
   filterViewportFeaturesToGetCategories
 } from 'src/widgets/models/CategoryModel';
 import { AggregationTypes } from 'src/widgets/AggregationTypes';
-import { LayerTypes } from 'src/widgets/LayerTypes';
+import { SourceTypes } from 'src/api';
 
 import { mockSqlApiRequest, mockClear } from '../../mockSqlApiRequest';
 
@@ -34,7 +34,7 @@ describe('getCategories', () => {
 
   test('should throw if using CartoBQTilerLayer without viewportFilter', async () => {
     await expect(
-      getCategories({ type: LayerTypes.BIGQUERY, viewportFilter: false })
+      getCategories({ type: SourceTypes.BIGQUERY, viewportFilter: false })
     ).rejects.toThrow(
       'Category Widget error: BigQuery layers need "viewportFilter" prop set to true.'
     );
@@ -67,7 +67,7 @@ describe('getCategories', () => {
           credentials,
           operation: AggregationTypes.COUNT,
           column: 'revenue',
-          type: LayerTypes.SQL,
+          type: SourceTypes.SQL,
           viewportFilter: false
         };
         const categories = await getCategories(params);
@@ -82,7 +82,7 @@ describe('getCategories', () => {
         operation,
         column: 'storetype',
         operationColumn: 'revenue',
-        type: LayerTypes.SQL,
+        type: SourceTypes.SQL,
         viewportFilter: true,
         viewportFeatures
       });

--- a/src/tests/widgets/models/FormulaModel.test.js
+++ b/src/tests/widgets/models/FormulaModel.test.js
@@ -6,7 +6,7 @@ import {
   filterViewportFeaturesToGetFormula
 } from 'src/widgets/models/FormulaModel';
 import { AggregationTypes } from 'src/widgets/AggregationTypes';
-import { LayerTypes } from 'src/widgets/LayerTypes';
+import { SourceTypes } from 'src/api';
 
 import { mockSqlApiRequest, mockClear } from '../../mockSqlApiRequest';
 
@@ -31,7 +31,7 @@ describe('getFormula', () => {
 
   test('should throw if using CartoBQTilerLayer without viewportFilter', async () => {
     await expect(
-      getFormula({ type: LayerTypes.BIGQUERY, viewportFilter: false })
+      getFormula({ type: SourceTypes.BIGQUERY, viewportFilter: false })
     ).rejects.toThrow(
       'Formula Widget error: BigQuery layers need "viewportFilter" prop set to true.'
     );
@@ -59,7 +59,7 @@ describe('getFormula', () => {
           credentials,
           operation: AggregationTypes.COUNT,
           column: 'revenue',
-          type: LayerTypes.SQL,
+          type: SourceTypes.SQL,
           viewportFilter: false
         };
         const func = await getFormula(params);
@@ -73,7 +73,7 @@ describe('getFormula', () => {
       const buildParamsFor = (operation) => ({
         operation,
         column: 'revenue',
-        type: LayerTypes.SQL,
+        type: SourceTypes.SQL,
         viewportFilter: true,
         viewportFeatures
       });

--- a/src/tests/widgets/models/FormulaModel.test.js
+++ b/src/tests/widgets/models/FormulaModel.test.js
@@ -31,7 +31,7 @@ describe('getFormula', () => {
 
   test('should throw if using CartoBQTilerLayer without viewportFilter', async () => {
     await expect(
-      getFormula({ type: LayerTypes.BQ, viewportFilter: false })
+      getFormula({ type: LayerTypes.BIGQUERY, viewportFilter: false })
     ).rejects.toThrow(
       'Formula Widget error: BigQuery layers need "viewportFilter" prop set to true.'
     );

--- a/src/tests/widgets/models/HistogramModel.test.js
+++ b/src/tests/widgets/models/HistogramModel.test.js
@@ -31,7 +31,7 @@ describe('getHistogram', () => {
 
   test('should throw if using CartoBQTilerLayer without viewportFilter', async () => {
     await expect(
-      getHistogram({ type: LayerTypes.BQ, viewportFilter: false })
+      getHistogram({ type: LayerTypes.BIGQUERY, viewportFilter: false })
     ).rejects.toThrow(
       'Histogram Widget error: BigQuery layer needs "viewportFilter" prop set to true.'
     );

--- a/src/tests/widgets/models/HistogramModel.test.js
+++ b/src/tests/widgets/models/HistogramModel.test.js
@@ -6,7 +6,7 @@ import {
   filterViewportFeaturesToGetHistogram
 } from 'src/widgets/models/HistogramModel';
 import { AggregationTypes } from 'src/widgets/AggregationTypes';
-import { LayerTypes } from 'src/widgets/LayerTypes';
+import { SourceTypes } from 'src/api';
 
 import { mockSqlApiRequest, mockClear } from '../../mockSqlApiRequest';
 
@@ -31,7 +31,7 @@ describe('getHistogram', () => {
 
   test('should throw if using CartoBQTilerLayer without viewportFilter', async () => {
     await expect(
-      getHistogram({ type: LayerTypes.BIGQUERY, viewportFilter: false })
+      getHistogram({ type: SourceTypes.BIGQUERY, viewportFilter: false })
     ).rejects.toThrow(
       'Histogram Widget error: BigQuery layer needs "viewportFilter" prop set to true.'
     );
@@ -73,7 +73,7 @@ describe('getHistogram', () => {
           operation: 'count',
           column: 'revenue',
           operationColumn: 'revenue',
-          type: LayerTypes.SQL,
+          type: SourceTypes.SQL,
           ticks: [1300000, 1400000, 1500000],
           viewportFilter: false
         };
@@ -100,7 +100,7 @@ describe('getHistogram', () => {
       const buildParamsFor = (operation) => ({
         operation,
         column: 'revenue',
-        type: LayerTypes.SQL,
+        type: SourceTypes.SQL,
         ticks: [1, 2, 3],
         viewportFilter: true,
         viewportFeatures

--- a/src/widgets/LayerTypes.js
+++ b/src/widgets/LayerTypes.js
@@ -8,5 +8,5 @@ export const LayerTypes = Object.freeze({
   SQL: 'sql',
 
   /** CartoBQTilerLayer */
-  BQ: 'bq'
+  BIGQUERY: 'bigquery'
 });

--- a/src/widgets/models/CategoryModel.js
+++ b/src/widgets/models/CategoryModel.js
@@ -1,10 +1,9 @@
 import { minify } from 'pgsql-minify';
-
 import { executeSQL } from '../../api';
-import { filtersToSQL } from '../../api/FilterQueryBuilder';
 import { buildFeatureFilter } from '../../api/Filter';
+import { filtersToSQL } from '../../api/FilterQueryBuilder';
+import { SourceTypes } from '../../api/SourceTypes';
 import { groupValuesByColumn } from '../operations/groupby';
-import { LayerTypes } from '../LayerTypes';
 
 export const getCategories = async (props) => {
   const {
@@ -23,7 +22,7 @@ export const getCategories = async (props) => {
     throw new Error('Array is not a valid type to get categories');
   }
 
-  if (type === LayerTypes.BIGQUERY && !viewportFilter) {
+  if (type === SourceTypes.BIGQUERY && !viewportFilter) {
     throw new Error(
       'Category Widget error: BigQuery layers need "viewportFilter" prop set to true.'
     );

--- a/src/widgets/models/CategoryModel.js
+++ b/src/widgets/models/CategoryModel.js
@@ -23,7 +23,7 @@ export const getCategories = async (props) => {
     throw new Error('Array is not a valid type to get categories');
   }
 
-  if (type === LayerTypes.BQ && !viewportFilter) {
+  if (type === LayerTypes.BIGQUERY && !viewportFilter) {
     throw new Error(
       'Category Widget error: BigQuery layers need "viewportFilter" prop set to true.'
     );

--- a/src/widgets/models/FormulaModel.js
+++ b/src/widgets/models/FormulaModel.js
@@ -23,7 +23,7 @@ export const getFormula = async (props) => {
     throw new Error('Array is not a valid type to get formula');
   }
 
-  if (type === LayerTypes.BQ && !viewportFilter) {
+  if (type === LayerTypes.BIGQUERY && !viewportFilter) {
     throw new Error(
       'Formula Widget error: BigQuery layers need "viewportFilter" prop set to true.'
     );

--- a/src/widgets/models/FormulaModel.js
+++ b/src/widgets/models/FormulaModel.js
@@ -1,10 +1,9 @@
 import { minify } from 'pgsql-minify';
-
 import { executeSQL } from '../../api';
-import { filtersToSQL } from '../../api/FilterQueryBuilder';
 import { buildFeatureFilter } from '../../api/Filter';
+import { filtersToSQL } from '../../api/FilterQueryBuilder';
+import { SourceTypes } from '../../api/SourceTypes';
 import { aggregationFunctions } from '../operations/aggregation/values';
-import { LayerTypes } from '../LayerTypes';
 
 export const getFormula = async (props) => {
   const {
@@ -23,7 +22,7 @@ export const getFormula = async (props) => {
     throw new Error('Array is not a valid type to get formula');
   }
 
-  if (type === LayerTypes.BIGQUERY && !viewportFilter) {
+  if (type === SourceTypes.BIGQUERY && !viewportFilter) {
     throw new Error(
       'Formula Widget error: BigQuery layers need "viewportFilter" prop set to true.'
     );

--- a/src/widgets/models/HistogramModel.js
+++ b/src/widgets/models/HistogramModel.js
@@ -24,7 +24,7 @@ export const getHistogram = async (props) => {
     throw new Error('Array is not a valid type to get histogram');
   }
 
-  if (type === LayerTypes.BQ && !viewportFilter) {
+  if (type === LayerTypes.BIGQUERY && !viewportFilter) {
     throw new Error(
       'Histogram Widget error: BigQuery layer needs "viewportFilter" prop set to true.'
     );

--- a/src/widgets/models/HistogramModel.js
+++ b/src/widgets/models/HistogramModel.js
@@ -1,10 +1,9 @@
 import { minify } from 'pgsql-minify';
-
 import { executeSQL } from '../../api';
-import { filtersToSQL } from '../../api/FilterQueryBuilder';
 import { buildFeatureFilter } from '../../api/Filter';
+import { filtersToSQL } from '../../api/FilterQueryBuilder';
+import { SourceTypes } from '../../api/SourceTypes';
 import { histogram } from '../operations/histogram';
-import { LayerTypes } from '../LayerTypes';
 
 export const getHistogram = async (props) => {
   const {
@@ -24,7 +23,7 @@ export const getHistogram = async (props) => {
     throw new Error('Array is not a valid type to get histogram');
   }
 
-  if (type === LayerTypes.BIGQUERY && !viewportFilter) {
+  if (type === SourceTypes.BIGQUERY && !viewportFilter) {
     throw new Error(
       'Histogram Widget error: BigQuery layer needs "viewportFilter" prop set to true.'
     );


### PR DESCRIPTION
Rename BigQuery source type, from `bq` to `bigquery`

For: https://app.clubhouse.io/cartoteam/story/135148/rename-source-type-in-template

Related with: https://github.com/CartoDB/carto-react-template/pull/203