### PR TITLE
test: add detectTouchScreen & improve Category Widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/react-hooks": "^5.0.3",
+    "@testing-library/user-event": "^12.7.0",
     "@turf/bbox-polygon": "^6.0.1",
     "@turf/boolean-contains": "^6.3.0",
     "@turf/boolean-intersects": "^6.0.2",

--- a/src/tests/ui/CategoryWidgetUI.test.js
+++ b/src/tests/ui/CategoryWidgetUI.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CategoryWidgetUI } from 'src/ui';
 import { currencyFormatter } from './utils';
 
@@ -17,6 +18,12 @@ describe('CategoryWidgetUI', () => {
 
     expect(screen.getByText(NO_DATA_TEXT)).toBeInTheDocument();
     expect(screen.getByText(NO_RESULT_TEXT)).toBeInTheDocument();
+  });
+
+  test('item skeleton should display', () => {
+    const { container } = render(<CategoryWidgetUI data={[]} isLoading={true} />);
+
+    expect(container.querySelector('.MuiSkeleton-root')).toBeInTheDocument();
   });
 
   test('simple', () => {
@@ -37,6 +44,22 @@ describe('CategoryWidgetUI', () => {
     render(<CategoryWidgetUI data={DATA} selectedCategories={['Category 1']} />);
 
     expect(screen.getByText(/1 selected/)).toBeInTheDocument();
+  });
+
+  describe('order', () => {
+    test('ranking', () => {
+      render(<CategoryWidgetUI data={DATA} />);
+
+      const renderedCategories = screen.getAllByText(/Category/);
+      expect(renderedCategories[0].textContent).toBe('Category 5');
+    });
+
+    test('fixed', () => {
+      render(<CategoryWidgetUI data={DATA} order='fixed' />);
+
+      const renderedCategories = screen.getAllByText(/Category/);
+      expect(renderedCategories[0].textContent).toBe('Category 1');
+    });
   });
 
   describe('events', () => {
@@ -113,6 +136,23 @@ describe('CategoryWidgetUI', () => {
       fireEvent.click(screen.getByText(/Apply/));
       fireEvent.click(screen.getByText(/Unlock/));
       expect(mockOnSelectedCategoriesChange).toHaveBeenCalledTimes(2);
+    });
+
+    test('search category', () => {
+      HTMLElement.prototype.scrollIntoView = jest.fn();
+      const mockOnSelectedCategoriesChange = jest.fn();
+      render(
+        <CategoryWidgetUI
+          data={DATA}
+          maxItems={1}
+          onSelectedCategoriesChange={mockOnSelectedCategoriesChange}
+        />
+      );
+
+      fireEvent.click(screen.getByText(/Search in 4 elements/));
+      userEvent.type(screen.getByRole('textbox'), 'Category 1');
+      fireEvent.click(screen.getByText(/Category 1/));
+      fireEvent.click(screen.getByText(/Apply/));
     });
 
     test('cancel search', () => {

--- a/src/tests/ui/utils/detectTouchScreen.test.js
+++ b/src/tests/ui/utils/detectTouchScreen.test.js
@@ -1,0 +1,56 @@
+import detectTouchscreen from 'src/ui/utils/detectTouchScreen';
+
+describe('detect touch screen', () => {
+  describe('supported', () => {
+    beforeEach(() => {
+      window.PointerEvent = true;
+      navigator.maxTouchPoints = 0;
+    });
+
+    afterAll(() => {
+      window.PointerEvent = false;
+      delete navigator.maxTouchPoints;
+    });
+
+    test('maxTouchPoints is less than or equal to 0', () => {
+      const IS_TOUCH_SCREEN = detectTouchscreen();
+      expect(IS_TOUCH_SCREEN).toBe(false);
+    });
+
+    test('maxTouchPoints is greather than 0', () => {
+      navigator.maxTouchPoints = 1;
+      const IS_TOUCH_SCREEN = detectTouchscreen();
+      expect(IS_TOUCH_SCREEN).toBe(true);
+    });
+  });
+
+  describe('not supported', () => {
+    beforeAll(() => {
+      window.matchMedia = () => ({ matches: true });
+    });
+
+    test('matchMedia matches', () => {
+      const IS_TOUCH_SCREEN = detectTouchscreen();
+      expect(IS_TOUCH_SCREEN).toBe(true);
+      window.matchMedia = () => ({ matches: false });
+    });
+
+    describe('matchMedia does not matches', () => {
+      beforeAll(() => {
+        window.matchMedia = () => ({ matches: false });
+      });
+
+      test('window.TouchEvent in truthy', () => {
+        window.TouchEvent = true;
+        const IS_TOUCH_SCREEN = detectTouchscreen();
+        expect(IS_TOUCH_SCREEN).toBe(true);
+      });
+
+      test('ontouchstart is in window', () => {
+        window.ontouchstart = true;
+        const IS_TOUCH_SCREEN = detectTouchscreen();
+        expect(IS_TOUCH_SCREEN).toBe(true);
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,6 +2675,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^12.7.0":
+  version "12.7.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.7.0.tgz#39084ab8c777f6113980b80b8a25f2b7e349f8aa"
+  integrity sha512-KzRM1KNDoW8pJ2HTenrUhTjV6wJMHvWAagDs8DDrYSWz6y4PN+K2jSvlm2bMHWNRk5LTJPo9jqIjNjJ3FlqXNw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@turf/bbox-polygon@^6.0.1":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-6.3.0.tgz#9ffa79d56ae50cc7730b35b2a6d2a02493268365"


### PR DESCRIPTION
- Add `detectTouchScreen`
- Add some new Category Widget tests (order and user category input search)

For: https://app.clubhouse.io/cartoteam/story/133201/test-suites-at-lib-project-ii