### PR TITLE
toggle viewportFilter prop to true by default

### DIFF
--- a/docs/api-reference/widgets.md
+++ b/docs/api-reference/widgets.md
@@ -4,34 +4,34 @@
 
 Renders a `<CategoryWidget />` component
 
-| Param                   | Type                                                 | Default            | Description                                                                                                      |
-| ----------------------- | ---------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| props                   |                                                      |                    |                                                                                                                  |
-| props.id                | <code>string</code>                                  |                    | ID for the widget instance.                                                                                      |
-| props.title             | <code>string</code>                                  |                    | Title to show in the widget header.                                                                              |
-| props.dataSource        | <code>string</code>                                  |                    | ID of the data source to get the data from.                                                                      |
-| props.column            | <code>string</code>                                  |                    | Name of the data source's column to get the data from.                                                           |
-| [props.operationColumn] | <code>string</code>                                  |                    | Name of the data source's column to operate with. If not defined it will default to the one defined in `column`. |
-| props.operation         | <code>string</code>                                  |                    | Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object.            |
-| [props.formatter]       | [<code>formatterCallback</code>](#formatterCallback) |                    | Function to format each value returned.                                                                          |
-| [props.viewportFilter]  | <code>boolean</code>                                 | <code>false</code> | Defines whether filter by the viewport or globally.                                                              |
-| [props.onError]         | [<code>errorCallback</code>](#errorCallback)         |                    | Function to handle error messages from the widget.                                                               |
+| Param                   | Type                                                 | Default           | Description                                                                                                      |
+| ----------------------- | ---------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| props                   |                                                      |                   |                                                                                                                  |
+| props.id                | <code>string</code>                                  |                   | ID for the widget instance.                                                                                      |
+| props.title             | <code>string</code>                                  |                   | Title to show in the widget header.                                                                              |
+| props.dataSource        | <code>string</code>                                  |                   | ID of the data source to get the data from.                                                                      |
+| props.column            | <code>string</code>                                  |                   | Name of the data source's column to get the data from.                                                           |
+| [props.operationColumn] | <code>string</code>                                  |                   | Name of the data source's column to operate with. If not defined it will default to the one defined in `column`. |
+| props.operation         | <code>string</code>                                  |                   | Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object.            |
+| [props.formatter]       | [<code>formatterCallback</code>](#formatterCallback) |                   | Function to format each value returned.                                                                          |
+| [props.viewportFilter]  | <code>boolean</code>                                 | <code>true</code> | Defines whether filter by the viewport or globally.                                                              |
+| [props.onError]         | [<code>errorCallback</code>](#errorCallback)         |                   | Function to handle error messages from the widget.                                                               |
 
 ## FormulaWidget
 
 Renders a `<FormulaWidget />` component
 
-| Param                  | Type                                                 | Default            | Description                                                                                           |
-| ---------------------- | ---------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------- |
-| props                  |                                                      |                    |                                                                                                       |
-| props.id               | <code>string</code>                                  |                    | ID for the widget instance.                                                                           |
-| props.title            | <code>string</code>                                  |                    | Title to show in the widget header.                                                                   |
-| props.dataSource       | <code>string</code>                                  |                    | ID of the data source to get the data from.                                                           |
-| props.column           | <code>string</code>                                  |                    | Name of the data source's column to get the data from.                                                |
-| props.operation        | <code>string</code>                                  |                    | Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object. |
-| [props.formatter]      | [<code>formatterCallback</code>](#formatterCallback) |                    | Function to format each value returned.                                                               |
-| [props.viewportFilter] | <code>boolean</code>                                 | <code>false</code> | Defines whether filter by the viewport or globally.                                                   |
-| [props.onError]        | [<code>errorCallback</code>](#errorCallback)         |                    | Function to handle error messages from the widget.                                                    |
+| Param                  | Type                                                 | Default           | Description                                                                                           |
+| ---------------------- | ---------------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
+| props                  |                                                      |                   |                                                                                                       |
+| props.id               | <code>string</code>                                  |                   | ID for the widget instance.                                                                           |
+| props.title            | <code>string</code>                                  |                   | Title to show in the widget header.                                                                   |
+| props.dataSource       | <code>string</code>                                  |                   | ID of the data source to get the data from.                                                           |
+| props.column           | <code>string</code>                                  |                   | Name of the data source's column to get the data from.                                                |
+| props.operation        | <code>string</code>                                  |                   | Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object. |
+| [props.formatter]      | [<code>formatterCallback</code>](#formatterCallback) |                   | Function to format each value returned.                                                               |
+| [props.viewportFilter] | <code>boolean</code>                                 | <code>true</code> | Defines whether filter by the viewport or globally.                                                   |
+| [props.onError]        | [<code>errorCallback</code>](#errorCallback)         |                   | Function to handle error messages from the widget.                                                    |
 
 ## GeocoderWidget
 
@@ -48,19 +48,19 @@ Renders a `<GeocoderWidget />` component
 
 Renders a `<HistogramWidget />` component
 
-| Param                  | Type                                                 | Default            | Description                                                                                           |
-| ---------------------- | ---------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------- |
-| props                  |                                                      |                    |                                                                                                       |
-| props.id               | <code>string</code>                                  |                    | ID for the widget instance.                                                                           |
-| props.title            | <code>string</code>                                  |                    | Title to show in the widget header.                                                                   |
-| props.dataSource       | <code>string</code>                                  |                    | ID of the data source to get the data from.                                                           |
-| props.column           | <code>string</code>                                  |                    | Name of the data source's column to get the data from.                                                |
-| props.operation        | <code>string</code>                                  |                    | Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object. |
-| props.ticks            | <code>Array.&lt;number&gt;</code>                    |                    | Array of thresholds for the X axis.                                                                   |
-| [props.xAxisformatter] | [<code>formatterCallback</code>](#formatterCallback) |                    | Function to format X axis values.                                                                     |
-| [props.formatter]      | [<code>formatterCallback</code>](#formatterCallback) |                    | Function to format tooltip and Y axis values.                                                         |
-| [props.viewportFilter] | <code>boolean</code>                                 | <code>false</code> | Defines whether filter by the viewport or globally.                                                   |
-| [props.onError]        | [<code>errorCallback</code>](#errorCallback)         |                    | Function to handle error messages from the widget.                                                    |
+| Param                  | Type                                                 | Default           | Description                                                                                           |
+| ---------------------- | ---------------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
+| props                  |                                                      |                   |                                                                                                       |
+| props.id               | <code>string</code>                                  |                   | ID for the widget instance.                                                                           |
+| props.title            | <code>string</code>                                  |                   | Title to show in the widget header.                                                                   |
+| props.dataSource       | <code>string</code>                                  |                   | ID of the data source to get the data from.                                                           |
+| props.column           | <code>string</code>                                  |                   | Name of the data source's column to get the data from.                                                |
+| props.operation        | <code>string</code>                                  |                   | Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object. |
+| props.ticks            | <code>Array.&lt;number&gt;</code>                    |                   | Array of thresholds for the X axis.                                                                   |
+| [props.xAxisformatter] | [<code>formatterCallback</code>](#formatterCallback) |                   | Function to format X axis values.                                                                     |
+| [props.formatter]      | [<code>formatterCallback</code>](#formatterCallback) |                   | Function to format tooltip and Y axis values.                                                         |
+| [props.viewportFilter] | <code>boolean</code>                                 | <code>true</code> | Defines whether filter by the viewport or globally.                                                   |
+| [props.onError]        | [<code>errorCallback</code>](#errorCallback)         |                   | Function to handle error messages from the widget.                                                    |
 
 ## PieWidget
 
@@ -77,7 +77,7 @@ Renders a `<PieWidget />` component
 | props.operation          | <code>string</code>                                  |                    | Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object.            |
 | [props.formatter]        | [<code>formatterCallback</code>](#formatterCallback) |                    | Function to format each value returned.                                                                          |
 | [props.tooltipFormatter] | [<code>formatterCallback</code>](#formatterCallback) |                    | Function to return the HTML of the tooltip.                                                                      |
-| [props.viewportFilter]   | <code>boolean</code>                                 | <code>false</code> | Defines whether filter by the viewport or not.                                                                   |
+| [props.viewportFilter]   | <code>boolean</code>                                 | <code>true</code>  | Defines whether filter by the viewport or not.                                                                   |
 | props.height             | <code>string</code>                                  | <code>300px</code> | Height of the chart in CSS format.                                                                               |
 | [props.onError]          | [<code>errorCallback</code>](#errorCallback)         |                    | Function to handle error messages from the widget.                                                               |
 


### PR DESCRIPTION
For: https://app.clubhouse.io/cartoteam/story/140406/toggle-viewportfilter-default

This PR allows as well both modes at the same time. Some widgets can have the global mode and others the client-side at the same time.