### PR TITLE
fix: animations on Category Widget (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix viewportFeatures with empty tiles [#100](https://github.com/CartoDB/carto-react-lib/pull/100)
 - Fix viewportFeatures mode in PieWidget when using viewportFilter [#102](https://github.com/CartoDB/carto-react-lib/pull/102)
 - BREAKING: Refactor into a new **multi-package** project [#104](https://github.com/CartoDB/carto-react-lib/pull/104)
+- Fix animations in Category Widget [#108](https://github.com/CartoDB/carto-react-lib/pull/108)
 
 ## 1.0.0-beta14 (2021-02-08)
 

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -146,7 +146,7 @@ function CategoryWidgetUI(props) {
   const [animValues, setAnimValues] = useState([]);
   const requestRef = useRef();
   const prevAnimValues = usePrevious(animValues);
-  const referencedPrevAnimValues = useRef(prevAnimValues);
+  const referencedPrevAnimValues = useRef();
   const classes = useStyles();
 
   // Get blockedCategories in the same order as original data
@@ -331,6 +331,10 @@ function CategoryWidgetUI(props) {
     searchValue,
     showAll
   ]);
+
+  useEffect(() => {
+    referencedPrevAnimValues.current = prevAnimValues;
+  }, [prevAnimValues]);
 
   useEffect(() => {
     animateValues({


### PR DESCRIPTION
For: https://app.clubhouse.io/cartoteam/story/140894/category-widget-does-not-include-animations-anymore