### PR TITLE
HistogramWidgetUI - yAxis always show max value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 - Histogram tooltip formatter receiving dataIndex and ticks [#220](https://github.com/CartoDB/carto-react/pull/220)
+- Histogram yAxis max value should always be shown [#221](https://github.com/CartoDB/carto-react/pull/221)
 
 ## 1.1.0-beta.3 (2021-10-27)
 

--- a/packages/react-ui/src/widgets/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI.js
@@ -112,7 +112,6 @@ function __generateDefaultConfig(
         showMinLabel: false,
         inside: true,
         color: (value) => {
-          // FIXME: Workaround to show only maxlabel
           let col = 'transparent';
           const maxValue = Math.max(...data.map((d) => d || Number.MIN_SAFE_INTEGER));
           if (value >= maxValue) {


### PR DESCRIPTION
https://app.shortcut.com/cartoteam/story/188715/the-y-axis-value-is-not-always-shown-in-the-histogram-widget

Before fix:

https://user-images.githubusercontent.com/9006480/139251294-71b2be7e-2419-42e1-8621-034f61df83e6.mov

After this fix:

https://user-images.githubusercontent.com/9006480/139251336-37a9c343-4611-443b-9b64-50f7830be4ce.mov

