### PR TITLE
docs(repo): Fix broken C4R documentation link

### DIFF
--- a/packages/react-api/README.md
+++ b/packages/react-api/README.md
@@ -14,4 +14,4 @@
 
 Package to access CARTO APIs.
 
-See the official doc & reference at [CARTO for React](https://docs.carto.com/react/)
+See the official doc & reference at [CARTO for React](https://docs.carto.com/carto-for-developers/carto-for-react/)

--- a/packages/react-auth/README.md
+++ b/packages/react-auth/README.md
@@ -14,4 +14,4 @@
 
 Package to use CARTO OAuth system.
 
-See the official doc & reference at [CARTO for React](https://docs.carto.com/react/)
+See the official doc & reference at [CARTO for React](https://docs.carto.com/carto-for-developers/carto-for-react/)

--- a/packages/react-basemaps/README.md
+++ b/packages/react-basemaps/README.md
@@ -14,4 +14,4 @@
 
 Package to use CARTO basemaps + an easy to use GoogleMap React component
 
-See the official doc & reference at [CARTO for React](https://docs.carto.com/react/)
+See the official doc & reference at [CARTO for React](https://docs.carto.com/carto-for-developers/carto-for-react/)

--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -14,4 +14,4 @@
 
 Package with core elements, used by different packages
 
-See the official doc & reference at [CARTO for React](https://docs.carto.com/react/)
+See the official doc & reference at [CARTO for React](https://docs.carto.com/carto-for-developers/carto-for-react/)

--- a/packages/react-redux/README.md
+++ b/packages/react-redux/README.md
@@ -14,4 +14,4 @@
 
 Package with CARTO utilities for a React + Redux project
 
-See the official doc & reference at [CARTO for React](https://docs.carto.com/react/)
+See the official doc & reference at [CARTO for React](https://docs.carto.com/carto-for-developers/carto-for-react/)

--- a/packages/react-widgets/README.md
+++ b/packages/react-widgets/README.md
@@ -14,4 +14,4 @@
 
 Package to use CARTO UI widgets + advanced filters within a React + Redux project
 
-See the official doc & reference at [CARTO for React](https://docs.carto.com/react/)
+See the official doc & reference at [CARTO for React](https://docs.carto.com/carto-for-developers/carto-for-react/)

--- a/packages/react-workers/README.md
+++ b/packages/react-workers/README.md
@@ -14,4 +14,4 @@
 
 Package to use CARTO Workers system.
 
-See the official doc & reference at [CARTO for React](https://docs.carto.com/react/)
+See the official doc & reference at [CARTO for React](https://docs.carto.com/carto-for-developers/carto-for-react/)


### PR DESCRIPTION
# Description

Fixes broken link to CARTO for React documentation.

## Type of change

- Documentation

#### PR Dependency Tree


* **PR #936** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)